### PR TITLE
Switching from rust-crypto to RustCrypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,15 @@ path = "./src/lib.rs"
 iron = [ "typemap" ]
 
 [dependencies]
+aead = "0.2.0"
+aes-gcm = "0.5"
 byteorder = "1"
+chacha20poly1305 = "0.4.1"
 chrono = "0.4"
 data-encoding = "2.0.0"
+generic-array = "0.12"
+hmac = "0.7"
 log = "0.3"
-rust-crypto = "0.2"
 rand = "0.3"
+sha2 = "0.8"
 typemap = { version = "0.3", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,17 @@
 
 #![deny(missing_docs)]
 
+extern crate aead;
+extern crate aes_gcm;
 extern crate byteorder;
+extern crate chacha20poly1305;
 extern crate chrono;
-extern crate crypto;
 extern crate data_encoding;
+extern crate hmac;
 #[macro_use]
 extern crate log;
 extern crate rand;
+extern crate sha2;
 #[cfg(feature = "iron")]
 extern crate typemap;
 


### PR DESCRIPTION
rust-crypto is not maintained anymore thus switching
to a different library should be the way to go.

### Changes

* Added new Error Case for being unable to encrypt
* Nonce size increased for ChaCha20Poly1305CsrfProtection from 8 to 12.

### Further Info

https://rustsec.org/advisories/RUSTSEC-2016-0005

Fixes: #16 