### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ path = "./src/lib.rs"
 iron = [ "typemap" ]
 
 [dependencies]
-aead = "0.3"
-aes-gcm = "0.6"
+aead = "0.4"
+aes-gcm = "0.9"
 byteorder = "1"
-chacha20poly1305 = "0.5"
+chacha20poly1305 = "0.8"
 chrono = "0.4"
 data-encoding = "2"
 generic-array = "0.14"
-hmac = "0.8"
+hmac = "0.11"
 log = "0.4"
-rand = "0.7"
+rand = "0.8"
 sha2 = "0.9"
 typemap = { version = "0.3", optional = true }

--- a/src/core.rs
+++ b/src/core.rs
@@ -233,7 +233,7 @@ impl HmacCsrfProtection {
     }
 
     fn hmac(&self) -> Hmac<Sha256> {
-        Hmac::<Sha256>::new_varkey(&self.hmac_key).expect("HMAC can take key of any size")
+        Hmac::<Sha256>::new_from_slice(&self.hmac_key).expect("HMAC can take key of any size")
     }
 }
 


### PR DESCRIPTION
Required by the merging of the `aesni` crate with the `aes` crate and
the subsequent yanking of the (transitive) `aes` 0.7.0 dependency.