### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ appveyor = { repository = "heartsucker/rust-csrf", branch = "master", service = 
 iron = ["typemap"]
 
 [dependencies]
-aead = "0.6.0-rc.1"
-aes-gcm = "0.11.0-rc.0"
-chacha20poly1305 = "0.11.0-rc.0"
-hmac = "0.13.0-rc.0"
-sha2 = { version = "0.11.0-rc.0" }
+aead = "0.6.0-rc.3"
+aes-gcm = "0.11.0-rc.2"
+chacha20poly1305 = "0.11.0-rc.2"
+hmac = "0.13.0-rc.3"
+sha2 = { version = "0.11.0-rc.3" }
 byteorder = "1"
 chrono = "0.4"
 data-encoding = "2.9"
-rand = "0.9"
+getrandom = { version = "0.3", features = ["std"] }
 typemap = { version = "0.3", optional = true }
 thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ iron = ["typemap"]
 [dependencies]
 aead = "0.6.0-rc.3"
 aes-gcm = "0.11.0-rc.2"
-chacha20poly1305 = "0.11.0-rc.2"
-hmac = "0.13.0-rc.3"
-sha2 = { version = "0.11.0-rc.3" }
 byteorder = "1"
+chacha20poly1305 = "0.11.0-rc.2"
 chrono = "0.4"
 data-encoding = "2.9"
 getrandom = { version = "0.3", features = ["std"] }
-typemap = { version = "0.3", optional = true }
+hmac = "0.13.0-rc.3"
+sha2 = { version = "0.11.0-rc.3" }
 thiserror = "2.0"
+typemap = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ appveyor = { repository = "heartsucker/rust-csrf", branch = "master", service = 
 iron = ["typemap"]
 
 [dependencies]
-aead = "0.6.0-rc.4"
-aes-gcm = "0.11.0-rc.2"
+aead = "0.6.0-rc.10"
+aes-gcm = "0.11.0-rc.3"
 byteorder = "1"
-chacha20poly1305 = "0.11.0-rc.2"
+chacha20poly1305 = "0.11.0-rc.3"
 chrono = "0.4"
-data-encoding = "2.9"
-getrandom = { version = "0.3", features = ["std"] }
-hmac = "0.13.0-rc.3"
-sha2 = { version = "0.11.0-rc.3" }
+data-encoding = "2.10"
+crypto-common = { version = "0.2.0", features = ["getrandom"] }
+hmac = "0.13.0-rc.5"
+sha2 = { version = "0.11.0-rc.5" }
 thiserror = "2.0"
 typemap = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "csrf"
-version = "0.4.1"
-edition = "2021"
+version = "0.5.0"
+edition = "2024"
 authors = ["heartsucker <heartsucker@autistici.org>"]
 description = "CSRF protection primitives"
 homepage = "https://github.com/heartsucker/rust-csrf"
@@ -16,22 +16,18 @@ categories = ["web-programming", "authentication", "cryptography"]
 travis-ci = { repository = "heartsucker/rust-csrf", branch = "master" }
 appveyor = { repository = "heartsucker/rust-csrf", branch = "master", service = "github" }
 
-[lib]
-name = "csrf"
-path = "./src/lib.rs"
-
 [features]
 iron = ["typemap"]
 
 [dependencies]
-aead = "0.5"
-aes-gcm = "0.10"
+aead = "0.6.0-rc.1"
+aes-gcm = "0.11.0-rc.0"
+chacha20poly1305 = "0.11.0-rc.0"
+hmac = "0.13.0-rc.0"
+sha2 = { version = "0.11.0-rc.0" }
 byteorder = "1"
-chacha20poly1305 = "0.10"
 chrono = "0.4"
-data-encoding = "2.0"
-generic-array = "1.0"
-hmac = "0.12"
-rand = "0.8"
-sha2 = "0.10"
+data-encoding = "2.9"
+rand = "0.9"
 typemap = { version = "0.3", optional = true }
+thiserror = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ appveyor = { repository = "heartsucker/rust-csrf", branch = "master", service = 
 iron = ["typemap"]
 
 [dependencies]
-aead = "0.6.0-rc.3"
+aead = "0.6.0-rc.4"
 aes-gcm = "0.11.0-rc.2"
 byteorder = "1"
 chacha20poly1305 = "0.11.0-rc.2"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -5,33 +5,34 @@ extern crate data_encoding;
 #[cfg(test)]
 extern crate test;
 
+const KEY_32: [u8; 32] = *b"01234567012345670123456701234567";
+const KEY_64: [u8; 64] = *b"0123456701234567012345670123456701234567012345670123456701234567";
+const TOKEN: [u8; 64] = *b"0123456701234567012345670123456701234567012345670123456701234567";
+
 macro_rules! benchmark {
-    ($strct: ident, $md: ident) => {
+    ($strct: ident, $md: ident, $key: ident) => {
         mod $md {
-            use csrf::{$strct, CsrfProtection};
+            use super::*;
+            use csrf::{CsrfProtection, $strct};
             use data_encoding::BASE64;
             use test::Bencher;
 
-            const KEY_32: [u8; 32] = *b"01234567012345670123456701234567";
-            const TOKEN: &[u8; 64] =
-                b"0123456701234567012345670123456701234567012345670123456701234567";
-
             #[bench]
             fn generate_pair(b: &mut Bencher) {
-                let protect = $strct::from_key(KEY_32);
+                let protect = $strct::from_key($key);
                 b.iter(|| {
-                    let _ = protect.generate_token_pair(Some(TOKEN), 3600);
+                    let _ = protect.generate_token_pair(Some(&TOKEN), 3600);
                 });
             }
 
             #[bench]
             fn validate_pair_success(b: &mut Bencher) {
-                let protect = $strct::from_key(KEY_32);
+                let protect = $strct::from_key($key);
                 let mut pairs = Vec::new();
 
                 for _ in 0..10 {
                     let (token, cookie) = protect
-                        .generate_token_pair(Some(TOKEN), 3600)
+                        .generate_token_pair(Some(&TOKEN), 3600)
                         .expect("failed to generate token");
                     let token = BASE64
                         .decode(token.b64_string().as_bytes())
@@ -53,12 +54,12 @@ macro_rules! benchmark {
 
             #[bench]
             fn parse_cookie_success(b: &mut Bencher) {
-                let protect = $strct::from_key(KEY_32);
+                let protect = $strct::from_key($key);
                 let mut cookies = Vec::new();
 
                 for _ in 0..10 {
                     let (_, cookie) = protect
-                        .generate_token_pair(Some(TOKEN), 3600)
+                        .generate_token_pair(Some(&TOKEN), 3600)
                         .expect("failed to generate cookie");
                     let cookie = BASE64
                         .decode(cookie.b64_string().as_bytes())
@@ -75,12 +76,12 @@ macro_rules! benchmark {
 
             #[bench]
             fn parse_token_success(b: &mut Bencher) {
-                let protect = $strct::from_key(KEY_32);
+                let protect = $strct::from_key($key);
                 let mut tokens = Vec::new();
 
                 for _ in 0..10 {
                     let (token, _) = protect
-                        .generate_token_pair(Some(TOKEN), 3600)
+                        .generate_token_pair(Some(&TOKEN), 3600)
                         .expect("failed to generate token");
                     let token = BASE64
                         .decode(token.b64_string().as_bytes())
@@ -97,12 +98,12 @@ macro_rules! benchmark {
 
             #[bench]
             fn parse_cookie_bad_sig(b: &mut Bencher) {
-                let protect = $strct::from_key(KEY_32);
+                let protect = $strct::from_key($key);
                 let mut cookies = Vec::new();
 
                 for _ in 0..10 {
                     let (_, cookie) = protect
-                        .generate_token_pair(Some(TOKEN), 3600)
+                        .generate_token_pair(Some(&TOKEN), 3600)
                         .expect("failed to generate cookie");
                     let mut cookie = BASE64
                         .decode(cookie.b64_string().as_bytes())
@@ -121,12 +122,12 @@ macro_rules! benchmark {
 
             #[bench]
             fn parse_token_bad_sig(b: &mut Bencher) {
-                let protect = $strct::from_key(KEY_32);
+                let protect = $strct::from_key($key);
                 let mut tokens = Vec::new();
 
                 for _ in 0..10 {
                     let (token, _) = protect
-                        .generate_token_pair(Some(TOKEN), 3600)
+                        .generate_token_pair(Some(&TOKEN), 3600)
                         .expect("failed to generate token");
                     let mut token = BASE64
                         .decode(token.b64_string().as_bytes())
@@ -145,12 +146,12 @@ macro_rules! benchmark {
 
             #[bench]
             fn parse_cookie_bad_value(b: &mut Bencher) {
-                let protect = $strct::from_key(KEY_32);
+                let protect = $strct::from_key($key);
                 let mut cookies = Vec::new();
 
                 for _ in 0..10 {
                     let (_, cookie) = protect
-                        .generate_token_pair(Some(TOKEN), 3600)
+                        .generate_token_pair(Some(&TOKEN), 3600)
                         .expect("failed to generate cookie");
                     let mut cookie = BASE64
                         .decode(cookie.b64_string().as_bytes())
@@ -168,12 +169,12 @@ macro_rules! benchmark {
 
             #[bench]
             fn parse_token_bad_value(b: &mut Bencher) {
-                let protect = $strct::from_key(KEY_32);
+                let protect = $strct::from_key($key);
                 let mut tokens = Vec::new();
 
                 for _ in 0..10 {
                     let (token, _) = protect
-                        .generate_token_pair(Some(TOKEN), 3600)
+                        .generate_token_pair(Some(&TOKEN), 3600)
                         .expect("failed to generate token");
                     let mut token = BASE64
                         .decode(token.b64_string().as_bytes())
@@ -192,6 +193,6 @@ macro_rules! benchmark {
     };
 }
 
-benchmark!(AesGcmCsrfProtection, aesgcm);
-benchmark!(ChaCha20Poly1305CsrfProtection, chacha20poly1305);
-benchmark!(HmacCsrfProtection, hmac);
+benchmark!(AesGcmCsrfProtection, aesgcm, KEY_32);
+benchmark!(ChaCha20Poly1305CsrfProtection, chacha20poly1305, KEY_32);
+benchmark!(HmacCsrfProtection, hmac, KEY_64);

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,12 +1,6 @@
 //! Module containing the core functionality for CSRF protection
 
-use std::{borrow::Cow, io::Cursor};
-
-use aead::{
-    Aead, AeadCore, KeyInit,
-    array::Array,
-    rand_core::{OsError, OsRng, TryRngCore},
-};
+use aead::{Aead, AeadCore, KeyInit, array::Array};
 use aes_gcm::Aes256Gcm;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use chacha20poly1305::ChaCha20Poly1305;
@@ -14,6 +8,7 @@ use chrono::{Duration, prelude::*};
 use data_encoding::{BASE64, BASE64URL};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+use std::{borrow::Cow, io::Cursor};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -31,7 +26,7 @@ pub enum CsrfError {
     EncryptionFailure(String),
     /// OsRng get random failure
     #[error("OsRng get random failed: {0}")]
-    OsRng(#[from] OsError),
+    OsRng(#[from] getrandom::Error),
 }
 
 /// A signed, encrypted CSRF token that is suitable to be displayed to end users.
@@ -179,7 +174,7 @@ pub trait CsrfProtection: Send + Sync {
         // TODO We had to get rid of `ring` because of `gcc` conflicts with `rust-crypto`, and
         // `ring`'s RNG didn't require mutability. Now create a new one per call which is not a
         // great idea.
-        OsRng.try_fill_bytes(buf).map_err(Into::into)
+        getrandom::fill(buf).map_err(Into::into)
     }
 
     /// Given an optional previous token and a TTL, generate a matching token and cookie pair.

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,40 +1,37 @@
 //! Module containing the core functionality for CSRF protection
 
-use std::{borrow::Cow, error::Error, fmt, io::Cursor};
+use std::{borrow::Cow, io::Cursor};
 
-use aead::{generic_array::GenericArray, Aead, AeadCore, Key, KeyInit};
+use aead::{
+    Aead, AeadCore, KeyInit,
+    array::Array,
+    rand_core::{OsError, OsRng, TryRngCore},
+};
 use aes_gcm::Aes256Gcm;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use chacha20poly1305::ChaCha20Poly1305;
-use chrono::{prelude::*, Duration};
+use chrono::{Duration, prelude::*};
 use data_encoding::{BASE64, BASE64URL};
 use hmac::{Hmac, Mac};
-use rand::RngCore;
 use sha2::Sha256;
 
 type HmacSha256 = Hmac<Sha256>;
 
 /// An `enum` of all CSRF related errors.
-#[derive(Debug, Hash, Eq, PartialEq, Clone)]
+#[derive(thiserror::Error, Debug, Eq, PartialEq, Clone)]
 pub enum CsrfError {
-    /// There was an internal error.
+    /// Library error
+    #[error("Internal error")]
     InternalError,
-    /// There was CSRF token validation failure.
+    /// Validation failure
+    #[error("Validation failed: {0}")]
     ValidationFailure(String),
-    /// There was a CSRF token encryption failure.
+    /// Encryption failure
+    #[error("Encryption failed: {0}")]
     EncryptionFailure(String),
-}
-
-impl Error for CsrfError {}
-
-impl fmt::Display for CsrfError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            CsrfError::InternalError => write!(f, "Library error"),
-            CsrfError::ValidationFailure(err) => write!(f, "Validation failed: {err}"),
-            CsrfError::EncryptionFailure(err) => write!(f, "Encryption failed: {err}"),
-        }
-    }
+    /// OsRng get random failure
+    #[error("OsRng get random failed: {0}")]
+    OsRng(#[from] OsError),
 }
 
 /// A signed, encrypted CSRF token that is suitable to be displayed to end users.
@@ -182,8 +179,7 @@ pub trait CsrfProtection: Send + Sync {
         // TODO We had to get rid of `ring` because of `gcc` conflicts with `rust-crypto`, and
         // `ring`'s RNG didn't require mutability. Now create a new one per call which is not a
         // great idea.
-        rand::rngs::OsRng.fill_bytes(buf);
-        Ok(())
+        OsRng.try_fill_bytes(buf).map_err(Into::into)
     }
 
     /// Given an optional previous token and a TTL, generate a matching token and cookie pair.
@@ -216,27 +212,17 @@ pub struct HmacCsrfProtection {
 
 impl HmacCsrfProtection {
     /// Returns n `HmacCsrfProtection` instance with auto generated key.
-    pub fn new() -> Self {
-        HmacCsrfProtection {
-            // Infallible
-            hmac: <HmacSha256 as Mac>::new_from_slice(&HmacSha256::generate_key(
-                &mut rand::rngs::OsRng,
-            ))
-            .unwrap(),
-        }
+    pub fn new() -> Result<Self, CsrfError> {
+        let key = HmacSha256::generate_key().map_err(CsrfError::from)?;
+        Ok(HmacCsrfProtection {
+            hmac: HmacSha256::new(&key),
+        })
     }
     /// Given an HMAC key, return an `HmacCsrfProtection` instance.
-    pub fn from_key(hmac_key: [u8; 32]) -> Self {
+    pub fn from_key(hmac_key: [u8; 64]) -> Self {
         HmacCsrfProtection {
-            // Infallible
-            hmac: <HmacSha256 as Mac>::new_from_slice(&hmac_key).unwrap(),
+            hmac: HmacSha256::new(&hmac_key.into()),
         }
-    }
-}
-
-impl Default for HmacCsrfProtection {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -326,28 +312,19 @@ pub struct AesGcmCsrfProtection {
 
 impl AesGcmCsrfProtection {
     /// Returns an `AesGcmCsrfProtection` instance with auto generated key.
-    pub fn new() -> Self {
-        AesGcmCsrfProtection {
+    pub fn new() -> Result<Self, CsrfError> {
+        Ok(AesGcmCsrfProtection {
             aead: {
-                let key = Aes256Gcm::generate_key(&mut rand::rngs::OsRng);
+                let key = Aes256Gcm::generate_key().map_err(CsrfError::from)?;
                 Aes256Gcm::new(&key)
             },
-        }
+        })
     }
     /// Given an AES256 key, return an `AesGcmCsrfProtection` instance.
     pub fn from_key(aead_key: [u8; 32]) -> Self {
         AesGcmCsrfProtection {
-            aead: {
-                let key = Key::<Aes256Gcm>::from_slice(&aead_key);
-                Aes256Gcm::new(key)
-            },
+            aead: { Aes256Gcm::new(&aead_key.into()) },
         }
-    }
-}
-
-impl Default for AesGcmCsrfProtection {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -368,7 +345,7 @@ impl CsrfProtection for AesGcmCsrfProtection {
         plaintext[32..40].copy_from_slice(&expires_bytes);
         plaintext[40..].copy_from_slice(token_value);
 
-        let nonce = Aes256Gcm::generate_nonce(&mut rand::rngs::OsRng);
+        let nonce = Aes256Gcm::generate_nonce().map_err(CsrfError::from)?;
 
         let ciphertext = self
             .aead
@@ -389,7 +366,7 @@ impl CsrfProtection for AesGcmCsrfProtection {
         self.random_bytes(&mut plaintext[0..32])?; // padding
         plaintext[32..].copy_from_slice(token_value);
 
-        let nonce = Aes256Gcm::generate_nonce(&mut rand::rngs::OsRng);
+        let nonce = Aes256Gcm::generate_nonce().map_err(CsrfError::from)?;
 
         let ciphertext = self
             .aead
@@ -413,11 +390,12 @@ impl CsrfProtection for AesGcmCsrfProtection {
             )));
         }
 
-        let nonce = GenericArray::from_slice(&cookie[0..12]);
+        // Infallible
+        let nonce = Array::try_from(&cookie[0..12]).unwrap();
 
         let plaintext = self
             .aead
-            .decrypt(nonce, cookie[12..].as_ref())
+            .decrypt(&nonce, cookie[12..].as_ref())
             .map_err(|err| {
                 CsrfError::ValidationFailure(format!("Failed to decrypt cookie: {err}"))
             })?;
@@ -440,14 +418,12 @@ impl CsrfProtection for AesGcmCsrfProtection {
             )));
         }
 
-        let nonce = GenericArray::from_slice(&token[0..12]);
+        // Infallible
+        let nonce = Array::try_from(&token[0..12]).unwrap();
 
-        let plaintext = self
-            .aead
-            .decrypt(nonce, token[12..].as_ref())
-            .map_err(|err| {
-                CsrfError::ValidationFailure(format!("Failed to decrypt token: {err}"))
-            })?;
+        let plaintext = self.aead.decrypt(&nonce, &token[12..]).map_err(|err| {
+            CsrfError::ValidationFailure(format!("Failed to decrypt token: {err}"))
+        })?;
 
         Ok(UnencryptedCsrfToken::new(plaintext[32..].to_vec()))
     }
@@ -461,23 +437,17 @@ pub struct ChaCha20Poly1305CsrfProtection {
 
 impl ChaCha20Poly1305CsrfProtection {
     /// Return a new `ChaCha20Poly1305CsrfProtection` instance with auto generated key.
-    pub fn new() -> Self {
-        ChaCha20Poly1305CsrfProtection {
-            aead: ChaCha20Poly1305::new(&ChaCha20Poly1305::generate_key(&mut rand::rngs::OsRng)),
-        }
+    pub fn new() -> Result<Self, CsrfError> {
+        let key = ChaCha20Poly1305::generate_key().map_err(CsrfError::from)?;
+        Ok(ChaCha20Poly1305CsrfProtection {
+            aead: ChaCha20Poly1305::new(&key),
+        })
     }
     /// Given a key, return a `ChaCha20Poly1305CsrfProtection` instance.
     pub fn from_key(aead_key: [u8; 32]) -> Self {
         ChaCha20Poly1305CsrfProtection {
-            // Infallibale
-            aead: ChaCha20Poly1305::new_from_slice(&aead_key).unwrap(),
+            aead: ChaCha20Poly1305::new(&aead_key.into()),
         }
-    }
-}
-
-impl Default for ChaCha20Poly1305CsrfProtection {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -498,7 +468,7 @@ impl CsrfProtection for ChaCha20Poly1305CsrfProtection {
         plaintext[32..40].copy_from_slice(&expires_bytes);
         plaintext[40..].copy_from_slice(token_value);
 
-        let nonce = ChaCha20Poly1305::generate_nonce(&mut rand::rngs::OsRng);
+        let nonce = ChaCha20Poly1305::generate_nonce().map_err(CsrfError::from)?;
 
         let ciphertext = self
             .aead
@@ -519,7 +489,7 @@ impl CsrfProtection for ChaCha20Poly1305CsrfProtection {
         self.random_bytes(&mut plaintext[0..32])?; // padding
         plaintext[32..].copy_from_slice(token_value);
 
-        let nonce = ChaCha20Poly1305::generate_nonce(&mut rand::rngs::OsRng);
+        let nonce = ChaCha20Poly1305::generate_nonce().map_err(CsrfError::from)?;
 
         let ciphertext = self
             .aead
@@ -543,11 +513,12 @@ impl CsrfProtection for ChaCha20Poly1305CsrfProtection {
             )));
         }
 
-        let nonce = GenericArray::from_slice(&cookie[0..12]);
+        // Infallible
+        let nonce = Array::try_from(&cookie[0..12]).unwrap();
 
         let plaintext = self
             .aead
-            .decrypt(nonce, cookie[12..].as_ref())
+            .decrypt(&nonce, cookie[12..].as_ref())
             .map_err(|err| {
                 CsrfError::ValidationFailure(format!("Failed to decrypt cookie: {err}"))
             })?;
@@ -570,11 +541,12 @@ impl CsrfProtection for ChaCha20Poly1305CsrfProtection {
             )));
         }
 
-        let nonce = GenericArray::from_slice(&token[0..12]);
+        // Infallible
+        let nonce = Array::try_from(&token[0..12]).unwrap();
 
         let plaintext = self
             .aead
-            .decrypt(nonce, token[12..].as_ref())
+            .decrypt(&nonce, token[12..].as_ref())
             .map_err(|err| {
                 CsrfError::ValidationFailure(format!("Failed to decrypt token: {err}"))
             })?;
@@ -656,19 +628,22 @@ mod tests {
     // TODO write test that ensures encrypted messages don't contain the plaintext
     // TODO test that checks tokens are repeated when given Some
 
+    const KEY_64: [u8; 64] = *b"0123456701234567012345670123456701234567012345670123456701234567";
+    const KEY2_64: [u8; 64] = *b"7654321076543210765432107654321076543210765432107654321076543210";
+
     const KEY_32: [u8; 32] = *b"01234567012345670123456701234567";
     const KEY2_32: [u8; 32] = *b"76543210765432107654321076543210";
 
     macro_rules! test_cases {
-        ($strct: ident, $md: ident) => {
+        ($strct: ident, $md: ident, $key: ident) => {
             mod $md {
-                use super::KEY_32;
+                use super::*;
                 use data_encoding::BASE64;
-                use $crate::{$strct, CsrfProtection};
+                use $crate::{CsrfProtection, $strct};
 
                 #[test]
                 fn verification_succeeds() {
-                    let protect = $strct::from_key(KEY_32);
+                    let protect = $strct::from_key($key);
                     let (token, cookie) = protect
                         .generate_token_pair(None, 300)
                         .expect("couldn't generate token/cookie pair");
@@ -688,7 +663,7 @@ mod tests {
 
                 #[test]
                 fn modified_cookie_value_fails() {
-                    let protect = $strct::from_key(KEY_32);
+                    let protect = $strct::from_key($key);
                     let (_, mut cookie) = protect
                         .generate_token_pair(None, 300)
                         .expect("couldn't generate token/cookie pair");
@@ -701,7 +676,7 @@ mod tests {
 
                 #[test]
                 fn modified_token_value_fails() {
-                    let protect = $strct::from_key(KEY_32);
+                    let protect = $strct::from_key($key);
                     let (mut token, _) = protect
                         .generate_token_pair(None, 300)
                         .expect("couldn't generate token/token pair");
@@ -714,7 +689,7 @@ mod tests {
 
                 #[test]
                 fn mismatched_cookie_token_fail() {
-                    let protect = $strct::from_key(KEY_32);
+                    let protect = $strct::from_key($key);
                     let (token, _) = protect
                         .generate_token_pair(None, 300)
                         .expect("couldn't generate token/token pair");
@@ -738,7 +713,7 @@ mod tests {
 
                 #[test]
                 fn expired_token_fail() {
-                    let protect = $strct::from_key(KEY_32);
+                    let protect = $strct::from_key($key);
                     let (token, cookie) = protect
                         .generate_token_pair(None, -1)
                         .expect("couldn't generate token/cookie pair");
@@ -759,20 +734,22 @@ mod tests {
         };
     }
 
-    test_cases!(AesGcmCsrfProtection, aesgcm);
-    test_cases!(ChaCha20Poly1305CsrfProtection, chacha20poly1305);
-    test_cases!(HmacCsrfProtection, hmac);
+    test_cases!(AesGcmCsrfProtection, aesgcm, KEY_32);
+    test_cases!(ChaCha20Poly1305CsrfProtection, chacha20poly1305, KEY_32);
+    test_cases!(HmacCsrfProtection, hmac, KEY2_64);
 
     mod multi {
+
         macro_rules! test_cases {
-            ($strct1: ident, $strct2: ident, $name: ident) => {
+            ($strct1: ident, $strct2: ident, $name: ident, $key: ident, $key2: ident) => {
                 mod $name {
-                    use super::super::{super::*, KEY2_32, KEY_32};
+                    #[allow(unused)]
+                    use super::super::{super::*, KEY_32, KEY_64, KEY2_32, KEY2_64};
                     use data_encoding::BASE64;
 
                     #[test]
                     fn no_previous() {
-                        let protect = $strct1::from_key(KEY_32);
+                        let protect = $strct1::from_key($key);
                         let mut pairs = vec![];
                         let pair = protect
                             .generate_token_pair(None, 300)
@@ -803,14 +780,14 @@ mod tests {
 
                     #[test]
                     fn $name() {
-                        let protect_1 = $strct1::from_key(KEY_32);
+                        let protect_1 = $strct1::from_key($key);
                         let mut pairs = vec![];
                         let pair = protect_1
                             .generate_token_pair(None, 300)
                             .expect("couldn't generate token/cookie pair");
                         pairs.push(pair);
 
-                        let protect_2 = $strct2::from_key(KEY2_32);
+                        let protect_2 = $strct2::from_key($key2);
                         let mut pairs = vec![];
                         let pair = protect_2
                             .generate_token_pair(None, 300)
@@ -848,41 +825,71 @@ mod tests {
         test_cases!(
             AesGcmCsrfProtection,
             AesGcmCsrfProtection,
-            aesgcm_then_aesgcm
+            aesgcm_then_aesgcm,
+            KEY_32,
+            KEY2_32
         );
 
         test_cases!(
             ChaCha20Poly1305CsrfProtection,
             ChaCha20Poly1305CsrfProtection,
-            chacha20poly1305_then_chacha20poly1305
+            chacha20poly1305_then_chacha20poly1305,
+            KEY_32,
+            KEY2_32
         );
 
-        test_cases!(HmacCsrfProtection, HmacCsrfProtection, hmac_then_hmac);
+        test_cases!(
+            HmacCsrfProtection,
+            HmacCsrfProtection,
+            hmac_then_hmac,
+            KEY_64,
+            KEY2_64
+        );
 
         test_cases!(
             ChaCha20Poly1305CsrfProtection,
             AesGcmCsrfProtection,
-            chacha20poly1305_then_aesgcm
+            chacha20poly1305_then_aesgcm,
+            KEY_32,
+            KEY2_32
         );
 
-        test_cases!(HmacCsrfProtection, AesGcmCsrfProtection, hmac_then_aesgcm);
+        test_cases!(
+            HmacCsrfProtection,
+            AesGcmCsrfProtection,
+            hmac_then_aesgcm,
+            KEY_64,
+            KEY2_32
+        );
 
         test_cases!(
             AesGcmCsrfProtection,
             ChaCha20Poly1305CsrfProtection,
-            aesgcm_then_chacha20poly1305
+            aesgcm_then_chacha20poly1305,
+            KEY_32,
+            KEY2_32
         );
         test_cases!(
             HmacCsrfProtection,
             ChaCha20Poly1305CsrfProtection,
-            hmac_then_chacha20poly1305
+            hmac_then_chacha20poly1305,
+            KEY_64,
+            KEY2_32
         );
 
-        test_cases!(AesGcmCsrfProtection, HmacCsrfProtection, aesgcm_then_hmac);
+        test_cases!(
+            AesGcmCsrfProtection,
+            HmacCsrfProtection,
+            aesgcm_then_hmac,
+            KEY_32,
+            KEY2_64
+        );
         test_cases!(
             ChaCha20Poly1305CsrfProtection,
             HmacCsrfProtection,
-            chacha20poly1305_then_hmac
+            chacha20poly1305_then_hmac,
+            KEY_32,
+            KEY2_64
         );
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -13,6 +13,7 @@ use std::{borrow::Cow, io::Cursor};
 type HmacSha256 = Hmac<Sha256>;
 
 /// An `enum` of all CSRF related errors.
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug, Eq, PartialEq, Clone)]
 pub enum CsrfError {
     /// Library error

--- a/src/core.rs
+++ b/src/core.rs
@@ -5,6 +5,7 @@ use aes_gcm::Aes256Gcm;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use chacha20poly1305::ChaCha20Poly1305;
 use chrono::{Duration, prelude::*};
+use crypto_common::getrandom;
 use data_encoding::{BASE64, BASE64URL};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,6 @@
 //! Module containing the core functionality for CSRF protection
 
-use aead::{Aead, AeadCore, KeyInit, array::Array};
+use aead::{Aead, Generate, Key, KeyInit, Nonce, array::Array};
 use aes_gcm::Aes256Gcm;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use chacha20poly1305::ChaCha20Poly1305;
@@ -209,7 +209,7 @@ pub struct HmacCsrfProtection {
 impl HmacCsrfProtection {
     /// Returns n `HmacCsrfProtection` instance with auto generated key.
     pub fn new() -> Result<Self, CsrfError> {
-        let key = HmacSha256::generate_key()?;
+        let key = Key::<HmacSha256>::try_generate()?;
         Ok(HmacCsrfProtection {
             hmac: HmacSha256::new(&key),
         })
@@ -311,7 +311,7 @@ impl AesGcmCsrfProtection {
     pub fn new() -> Result<Self, CsrfError> {
         Ok(AesGcmCsrfProtection {
             aead: {
-                let key = Aes256Gcm::generate_key()?;
+                let key = Key::<Aes256Gcm>::try_generate()?;
                 Aes256Gcm::new(&key)
             },
         })
@@ -341,7 +341,7 @@ impl CsrfProtection for AesGcmCsrfProtection {
         plaintext[32..40].copy_from_slice(&expires_bytes);
         plaintext[40..].copy_from_slice(token_value);
 
-        let nonce = Aes256Gcm::generate_nonce()?;
+        let nonce = Nonce::<Aes256Gcm>::try_generate()?;
 
         let ciphertext = self
             .aead
@@ -362,7 +362,7 @@ impl CsrfProtection for AesGcmCsrfProtection {
         self.random_bytes(&mut plaintext[0..32])?; // padding
         plaintext[32..].copy_from_slice(token_value);
 
-        let nonce = Aes256Gcm::generate_nonce()?;
+        let nonce = Nonce::<Aes256Gcm>::try_generate()?;
 
         let ciphertext = self
             .aead
@@ -434,7 +434,7 @@ pub struct ChaCha20Poly1305CsrfProtection {
 impl ChaCha20Poly1305CsrfProtection {
     /// Return a new `ChaCha20Poly1305CsrfProtection` instance with auto generated key.
     pub fn new() -> Result<Self, CsrfError> {
-        let key = ChaCha20Poly1305::generate_key()?;
+        let key = Key::<ChaCha20Poly1305>::try_generate()?;
         Ok(ChaCha20Poly1305CsrfProtection {
             aead: ChaCha20Poly1305::new(&key),
         })
@@ -464,7 +464,7 @@ impl CsrfProtection for ChaCha20Poly1305CsrfProtection {
         plaintext[32..40].copy_from_slice(&expires_bytes);
         plaintext[40..].copy_from_slice(token_value);
 
-        let nonce = ChaCha20Poly1305::generate_nonce()?;
+        let nonce = Nonce::<ChaCha20Poly1305>::try_generate()?;
 
         let ciphertext = self
             .aead
@@ -485,7 +485,7 @@ impl CsrfProtection for ChaCha20Poly1305CsrfProtection {
         self.random_bytes(&mut plaintext[0..32])?; // padding
         plaintext[32..].copy_from_slice(token_value);
 
-        let nonce = ChaCha20Poly1305::generate_nonce()?;
+        let nonce = Nonce::<ChaCha20Poly1305>::try_generate()?;
 
         let ciphertext = self
             .aead

--- a/src/core.rs
+++ b/src/core.rs
@@ -209,7 +209,7 @@ pub struct HmacCsrfProtection {
 impl HmacCsrfProtection {
     /// Returns n `HmacCsrfProtection` instance with auto generated key.
     pub fn new() -> Result<Self, CsrfError> {
-        let key = HmacSha256::generate_key().map_err(CsrfError::from)?;
+        let key = HmacSha256::generate_key()?;
         Ok(HmacCsrfProtection {
             hmac: HmacSha256::new(&key),
         })
@@ -311,7 +311,7 @@ impl AesGcmCsrfProtection {
     pub fn new() -> Result<Self, CsrfError> {
         Ok(AesGcmCsrfProtection {
             aead: {
-                let key = Aes256Gcm::generate_key().map_err(CsrfError::from)?;
+                let key = Aes256Gcm::generate_key()?;
                 Aes256Gcm::new(&key)
             },
         })
@@ -341,7 +341,7 @@ impl CsrfProtection for AesGcmCsrfProtection {
         plaintext[32..40].copy_from_slice(&expires_bytes);
         plaintext[40..].copy_from_slice(token_value);
 
-        let nonce = Aes256Gcm::generate_nonce().map_err(CsrfError::from)?;
+        let nonce = Aes256Gcm::generate_nonce()?;
 
         let ciphertext = self
             .aead
@@ -362,7 +362,7 @@ impl CsrfProtection for AesGcmCsrfProtection {
         self.random_bytes(&mut plaintext[0..32])?; // padding
         plaintext[32..].copy_from_slice(token_value);
 
-        let nonce = Aes256Gcm::generate_nonce().map_err(CsrfError::from)?;
+        let nonce = Aes256Gcm::generate_nonce()?;
 
         let ciphertext = self
             .aead
@@ -434,7 +434,7 @@ pub struct ChaCha20Poly1305CsrfProtection {
 impl ChaCha20Poly1305CsrfProtection {
     /// Return a new `ChaCha20Poly1305CsrfProtection` instance with auto generated key.
     pub fn new() -> Result<Self, CsrfError> {
-        let key = ChaCha20Poly1305::generate_key().map_err(CsrfError::from)?;
+        let key = ChaCha20Poly1305::generate_key()?;
         Ok(ChaCha20Poly1305CsrfProtection {
             aead: ChaCha20Poly1305::new(&key),
         })
@@ -464,7 +464,7 @@ impl CsrfProtection for ChaCha20Poly1305CsrfProtection {
         plaintext[32..40].copy_from_slice(&expires_bytes);
         plaintext[40..].copy_from_slice(token_value);
 
-        let nonce = ChaCha20Poly1305::generate_nonce().map_err(CsrfError::from)?;
+        let nonce = ChaCha20Poly1305::generate_nonce()?;
 
         let ciphertext = self
             .aead
@@ -485,7 +485,7 @@ impl CsrfProtection for ChaCha20Poly1305CsrfProtection {
         self.random_bytes(&mut plaintext[0..32])?; // padding
         plaintext[32..].copy_from_slice(token_value);
 
-        let nonce = ChaCha20Poly1305::generate_nonce().map_err(CsrfError::from)?;
+        let nonce = ChaCha20Poly1305::generate_nonce()?;
 
         let ciphertext = self
             .aead


### PR DESCRIPTION
This is a breaking change upgrade (for version 0.6.0):

- Default constructors are removed and they are not infallible anymore. 
- `HmacSha256` key block size key is 64 bytes instead of 32 bytes. 
- Updated to rand `0.9`.

Todo:

- [ ] Wait for the final release of rust crypto crates final release.